### PR TITLE
Fix typo in officialChannels.ts

### DIFF
--- a/src/core/db/streamers/officialChannels.ts
+++ b/src/core/db/streamers/officialChannels.ts
@@ -61,7 +61,7 @@ export const official_channels = [
   },
   {
     name: 'Hololive DEV_IS',
-    ydId: 'UC10wVt6hoQiwySRhz7RdOUA',
+    ytId: 'UC10wVt6hoQiwySRhz7RdOUA',
     chName: 'hololive DEV_IS',
     picture:
       'https://yt3.googleusercontent.com/KTypB1brQ2yd1KtZUBo4Y533L9kHmNeB1Q9aHZyfqWm3YE_6EOL10VYWj4LVRTwQ2jtg6hMyJQ=s800-c-k-c0x00ffffff-no-rj',


### PR DESCRIPTION
Apologies, there was a typo in officialChannels.ts. This PR fixes the typo.